### PR TITLE
aligning 404 pages

### DIFF
--- a/common/custom_theme/404.html
+++ b/common/custom_theme/404.html
@@ -1,5 +1,17 @@
 {% extends "main.html" %}
 
+
+<!-- style for centring the 404 content on the page -->
+<style>
+
+  .md-sidebar {
+    display: none;
+  }
+
+</style>
+
+
+
 <!-- Content block -->
 {% block content %}
 

--- a/common/custom_theme/404.html
+++ b/common/custom_theme/404.html
@@ -1,46 +1,32 @@
 {% extends "main.html" %}
 
-
-<!-- style for centring the 404 content on the page -->
-<style>
-
-  .md-sidebar {
-    display: none;
-  }
-
-</style>
-
-
-
 <!-- Content block -->
 {% block content %}
+<link rel="stylesheet" href="{{ 'assets/stylesheets/404.css' | url }}">
 
-<p style="text-align: center;font-size: 3em">
+<p>
   {% if config.extra.inverted_logo %}
-    <img src="{{ config.extra.inverted_logo | url }}" alt="logo">
+    <img src="{{ config.extra.inverted_logo | url }}" alt="{{config.site_name}} logo" class="logo_404">
   {% elif config.theme.logo %}
-    <img src="{{ config.theme.logo | url }}" alt="logo">
+    <img src="{{ config.theme.logo | url }}" alt="{{config.site_name}} logo" class="logo_404"s>
   {% else %}
     {% set icon = config.theme.icon.logo or "material/library" %}
     {% include ".icons/" ~ icon ~ ".svg" %}
   {% endif %}
 </p>
 
-<h1 id="404-page-not-found" style="text-align: center">404</h1>
-<p style="text-align: center"><strong>Sorry but we can't find the page you asked for.</strong></p>
-<p style="text-align: center">
+<h1>404</h1>
+<p><strong>Sorry but we can't find the page you asked for.</strong></p>
+<p>
   Try the <a href="/">homepage</a>, or use the search field on the top of this page.
 </p>
-<p style="text-align: center">
-  {% if config.extra.support.paid %}
-  If you think we made a mistake and deleted a page that should be here, then please tell <a href="{{config.extra.support.website}}">{{config.extra.support.company}}</a> at
-  <a href="mailto:{{config.extra.support.email}}">{{config.extra.support.email}}</a>.
-{% else %}
-  If you think we made a mistake and deleted a page that should be here, then please tell us on
-  <a href="{{config.extra.support.channel}}">{{config.site_name}} {{config.extra.support.tool}} channel</a> or create an issue in
-  <a href="{{config.extra.support.issues}}">issues</a>.
+
+{% if config.extra.support %}
+  <p>
+    If you think we made a mistake and deleted a page that should be here, please
+    <a href="{{config.extra.support | url }}">tell us</a>.
+  </p>
 {% endif %}
 
-</p>
-
 {% endblock %}
+{% block site_nav %}{% endblock %}

--- a/common/custom_theme/assets/stylesheets/404.css
+++ b/common/custom_theme/assets/stylesheets/404.css
@@ -1,0 +1,7 @@
+h1, p{
+  text-align: center;
+}
+
+.logo_404 {
+  height: 6rem !important;
+}

--- a/common/custom_theme/base.yml
+++ b/common/custom_theme/base.yml
@@ -32,8 +32,6 @@ extra:
     text: 'You are reading the development version of this documentation and
     some displayed features may not be available in the stable release.
     You can switch to stable version using the switch in the header.'
-  support:
-    company: !ENV [COMPANY ,'ConsenSys']
   analytics:
     provider: gtm
     gtmid: !ENV GTM_ID


### PR DESCRIPTION
404 pages are unaligned. This PR fixes that, hopefully, it's difficult to test properly. 

Page should look like this:
![Screenshot 2021-11-02 at 09 10 06](https://user-images.githubusercontent.com/50398315/139809188-c83e6501-fe31-4fe5-85b1-c54c46b07423.png)

Not this:
![Screenshot 2021-11-02 at 09 11 08](https://user-images.githubusercontent.com/50398315/139809275-573a6b21-bcd3-4c37-90eb-9248b812a29e.png)


