### PR TITLE
add ability to override scripts and styles

### DIFF
--- a/common/custom_theme/base.yml
+++ b/common/custom_theme/base.yml
@@ -29,17 +29,6 @@ theme:
     - navigation.top
     - navigation.indexes
 
-extra_css:
-  - assets/stylesheets/custom.css
-  - assets/stylesheets/version.css
-  - https://fonts.googleapis.com/icon?family=Material+Icons
-extra_javascript:
-  - assets/javascripts/version.js
-  - assets/javascripts/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
-  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
-  - assets/javascripts/accessiBe.js
-
 markdown_extensions:
   - toc:
       permalink: true

--- a/common/custom_theme/main.html
+++ b/common/custom_theme/main.html
@@ -36,7 +36,14 @@
       src="https://code.jquery.com/jquery-3.6.0.min.js"
       integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4="
       crossorigin="anonymous"></script>
+  <script src="{{ 'assets/javascripts/version.js' | url }}"></script>
+  <script src="{{ 'assets/javascripts/mathjax.js' | url }}"></script>
+  <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+  <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+  <script src="{{ 'assets/javascripts/accessiBe.js' | url }}"></script>
+
   {{ super() }}
+
   {% if config.extra.debug %}
     {% include "partials/debug.html" %}
   {% endif %}
@@ -44,6 +51,9 @@
 
 {% block styles %}
   {{ super() }}
+  <link rel="stylesheet" href="{{ 'assets/stylesheets/custom.css' | url }}">
+  <link rel="stylesheet" href="{{ 'assets/stylesheets/version.css' | url }}">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 {% endblock %}
 
 {% block announce %}


### PR DESCRIPTION
no need to relist previous scripts and styles anymore.
Usual extra_css and extra_javascript config can be used directly from the doc site config.