### PR TITLE
Fix image Git permission error

### DIFF
--- a/.github/workflows/pr_preview_publish.yml
+++ b/.github/workflows/pr_preview_publish.yml
@@ -1,7 +1,7 @@
 ---
 name: Publish PR preview
 
-on: [ pull_request ]
+on: [ pull_request_target ]
 
 env:
   IMAGE_NAME: doctools-builder-test
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout code from repos
         uses: actions/checkout@v3
         with:
-#          ref: refs/pull/${{ github.event.number }}/merge # required to pull the PR code instead of the main one
+          ref: refs/pull/${{ github.event.number }}/merge # required to pull the PR code instead of the main one
           fetch-depth: 0 # Required for mkdocs to be able to display pages last update info
 
       - name: Get additional Github env vars # vars from Github env, can not be modified by users

--- a/.github/workflows/pr_preview_publish.yml
+++ b/.github/workflows/pr_preview_publish.yml
@@ -16,9 +16,9 @@ jobs:
 
     steps:
       - name: Checkout code from repos
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
-          ref: refs/pull/${{ github.event.number }}/merge # required to pull the PR code instead of the main one
+#          ref: refs/pull/${{ github.event.number }}/merge # required to pull the PR code instead of the main one
           fetch-depth: 0 # Required for mkdocs to be able to display pages last update info
 
       - name: Get additional Github env vars # vars from Github env, can not be modified by users

--- a/.github/workflows/pr_preview_publish.yml
+++ b/.github/workflows/pr_preview_publish.yml
@@ -5,6 +5,7 @@ on: [ pull_request ]
 
 env:
   IMAGE_NAME: doctools-builder-test
+  WORKSPACE_DIR: /workspace
 
 jobs:
   deploy:
@@ -36,13 +37,16 @@ jobs:
         run: |
           docker build . --tag ${{ steps.generate_pr_slug.outputs.image }}
 
+      - name: provide git log read permission # see https://github.blog/2022-04-12-git-security-vulnerability-announced/
+        run: git config --global --add safe.directory $WORKSPACE_DIR
+
       - name: Build preview site
         shell: sh
         run: |
           docker run --rm \
           -e VERSION=test \
-          -v ${PWD}:/workspace \
-          -w /workspace \
+          -v ${PWD}:$WORKSPACE_DIR \
+          -w $WORKSPACE_DIR \
           ${{ steps.generate_pr_slug.outputs.image }} \
           build -s \
           --config-file /workspace/tests/mkdocs.yml

--- a/.github/workflows/pr_preview_publish.yml
+++ b/.github/workflows/pr_preview_publish.yml
@@ -15,6 +15,9 @@ jobs:
       pull-requests: write
 
     steps:
+      - run: |
+          sudo rm /etc/docker/daemon.json
+          sudo systemctl restart docker
       - name: Checkout code from repos
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/pr_preview_publish.yml
+++ b/.github/workflows/pr_preview_publish.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   deploy:
     name: Build and publish PR preview
-    runs-on: macos-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/pr_preview_publish.yml
+++ b/.github/workflows/pr_preview_publish.yml
@@ -1,7 +1,7 @@
 ---
 name: Publish PR preview
 
-on: [ pull_request_target ]
+on: [ pull_request ]
 
 env:
   IMAGE_NAME: doctools-builder-test
@@ -9,7 +9,7 @@ env:
 jobs:
   deploy:
     name: Build and publish PR preview
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/pr_preview_publish.yml
+++ b/.github/workflows/pr_preview_publish.yml
@@ -28,14 +28,12 @@ jobs:
       - name: Generate PR slug
         shell: sh
         id: generate_pr_slug
-        run: |
-          echo "::set-output name=slug::PR-${{ github.event.number }}"
-          echo "::set-output name=image::$IMAGE_NAME$GITHUB_SHA"
+        run: echo "::set-output name=slug::PR-${{ github.event.number }}"
 
       - name: Build test image
         shell: sh
         run: |
-          docker build . --tag ${{ steps.generate_pr_slug.outputs.image }} --build-arg WORKSPACE_DIR=$WORKSPACE_DIR
+          docker build . --tag $IMAGE_NAME --build-arg WORKSPACE_DIR=$WORKSPACE_DIR
 
       - name: Build preview site
         shell: sh
@@ -44,7 +42,7 @@ jobs:
           -e VERSION=test \
           -v ${PWD}:$WORKSPACE_DIR \
           -w $WORKSPACE_DIR \
-          ${{ steps.generate_pr_slug.outputs.image }} \
+          $IMAGE_NAME \
           build -s \
           --config-file /workspace/tests/mkdocs.yml
 

--- a/.github/workflows/pr_preview_publish.yml
+++ b/.github/workflows/pr_preview_publish.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   deploy:
     name: Build and publish PR preview
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/pr_preview_publish.yml
+++ b/.github/workflows/pr_preview_publish.yml
@@ -35,10 +35,7 @@ jobs:
       - name: Build test image
         shell: sh
         run: |
-          docker build . --tag ${{ steps.generate_pr_slug.outputs.image }}
-
-      - name: provide git log read permission # see https://github.blog/2022-04-12-git-security-vulnerability-announced/
-        run: git config --global --add safe.directory $WORKSPACE_DIR
+          docker build . --tag ${{ steps.generate_pr_slug.outputs.image }} --build-arg WORKSPACE_DIR=$WORKSPACE_DIR
 
       - name: Build preview site
         shell: sh

--- a/.github/workflows/pr_preview_publish.yml
+++ b/.github/workflows/pr_preview_publish.yml
@@ -15,9 +15,6 @@ jobs:
       pull-requests: write
 
     steps:
-      - run: |
-          sudo rm /etc/docker/daemon.json
-          sudo systemctl restart docker
       - name: Checkout code from repos
         uses: actions/checkout@v2
         with:
@@ -30,12 +27,14 @@ jobs:
       - name: Generate PR slug
         shell: sh
         id: generate_pr_slug
-        run: echo "::set-output name=slug::PR-${{ github.event.number }}"
+        run: |
+          echo "::set-output name=slug::PR-${{ github.event.number }}"
+          echo "::set-output name=image::$IMAGE_NAME$GITHUB_SHA"
 
       - name: Build test image
         shell: sh
         run: |
-          docker build . --tag $IMAGE_NAME
+          docker build . --tag ${{ steps.generate_pr_slug.outputs.image }}
 
       - name: Build preview site
         shell: sh
@@ -44,7 +43,7 @@ jobs:
           -e VERSION=test \
           -v ${PWD}:/workspace \
           -w /workspace \
-          $IMAGE_NAME \
+          ${{ steps.generate_pr_slug.outputs.image }} \
           build -s \
           --config-file /workspace/tests/mkdocs.yml
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
-FROM python:3.9-alpine
+FROM alpine:3.15
 
 ARG VERSION="local"
 ARG REVISION="none"
 ARG GITHUB_WORKFLOW="none"
 ARG GITHUB_RUN_ID="none"
 
-RUN apk upgrade --update-cache -a && \
-    apk add --no-cache \
-    git \
-    nodejs
+ENV PYTHONUNBUFFERED=1
+
+RUN apk add --update --no-cache python3 git nodejs && ln -sf python3 /usr/bin/python
+RUN python3 -m ensurepip
+RUN pip3 install --no-cache --upgrade pip setuptools
+
 COPY requirements.txt requirements.txt
 COPY mkdocs-macro-pluglets mkdocs-macro-pluglets
-RUN /usr/local/bin/python -m pip install --upgrade pip
-RUN pip install -r requirements.txt --no-cache-dir
+RUN python3 -m pip install --upgrade pip
+RUN pip3 install -r requirements.txt --no-cache-dir
 COPY common common
 
 EXPOSE 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ARG VERSION="local"
 ARG REVISION="none"
 ARG GITHUB_WORKFLOW="none"
 ARG GITHUB_RUN_ID="none"
+ARG WORKSPACE_DIR=/workspace
 
 RUN apk upgrade --update-cache -a && \
     apk add --no-cache \
@@ -16,9 +17,13 @@ RUN /usr/local/bin/python -m pip install --upgrade pip
 RUN pip install -r requirements.txt --no-cache-dir
 COPY common common
 
+# see https://github.blog/2022-04-12-git-security-vulnerability-announced/
+RUN git config --global --add safe.directory ${WORKSPACE_DIR}
+
 EXPOSE 8000
 
 # Build doc by default
+WORKDIR ${WORKSPACE_DIR}
 ENTRYPOINT ["mkdocs"]
 CMD ["serve", "--dev-addr", "0.0.0.0:8000"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
-FROM alpine:3.15
+FROM python:3.9-alpine
 
 ARG VERSION="local"
 ARG REVISION="none"
 ARG GITHUB_WORKFLOW="none"
 ARG GITHUB_RUN_ID="none"
 
-ENV PYTHONUNBUFFERED=1
-
-RUN apk add --update --no-cache python3 git nodejs && ln -sf python3 /usr/bin/python
-RUN python3 -m ensurepip
-RUN pip3 install --no-cache --upgrade pip setuptools
-
+RUN apk upgrade --update-cache -a && \
+    apk add --no-cache \
+    git \
+    nodejs
 COPY requirements.txt requirements.txt
 COPY mkdocs-macro-pluglets mkdocs-macro-pluglets
-RUN python3 -m pip install --upgrade pip
-RUN pip3 install -r requirements.txt --no-cache-dir
+RUN /usr/local/bin/python -m pip install --upgrade pip
+RUN pip install -r requirements.txt --no-cache-dir
 COPY common common
 
 EXPOSE 8000

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,14 @@
 mkdocs-material==7.3.6
-Markdown==3.3.4
+Markdown==3.3.7
 markdown-fenced-code-tabs==1.0.5
 markdown-include==0.6.0
 mkdocs-exclude==1.0.2
-mkdocs-redirects==1.0.3
-mkdocs-git-revision-date-localized-plugin==0.10.1
-plantuml-markdown==3.4.4
+mkdocs-redirects==1.0.4
+mkdocs-git-revision-date-localized-plugin==1.0.1
+plantuml-markdown==3.5.2
 mkdocs-minify-plugin==0.5.0
-mkdocs-video==1.1.0
-mkdocs-macros-plugin==0.6.0
+mkdocs-video==1.3.0
+mkdocs-macros-plugin==0.7.0
 jinja2==3.0.0
 
 # Consensys Mkdocs macro pluglets

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ markdown-fenced-code-tabs==1.0.5
 markdown-include==0.6.0
 mkdocs-exclude==1.0.2
 mkdocs-redirects==1.0.4
-mkdocs-git-revision-date-localized-plugin==1.0.1
+mkdocs-git-revision-date-localized-plugin==1.0.0
 plantuml-markdown==3.5.2
 mkdocs-minify-plugin==0.5.0
 mkdocs-video==1.3.0


### PR DESCRIPTION
When running docker image, we have an error on Git log plugin:

```
INFO     -  [macros] - Macros arguments: {'module_name': 'main', 'modules': ['mkdocs_macros_katacoda'], 'include_dir': '', 'include_yaml': [], 'j2_block_start_string': '', 'j2_block_end_string': '', 'j2_variable_start_string': '', 'j2_variable_end_string': '', 'on_undefined': 'keep', 'on_error_fail': False, 'verbose': False}
INFO     -  [macros] - Preinstalled modules:  mkdocs_macros_katacoda
INFO     -  [macros] - Found external Python module 'mkdocs_macros_katacoda' in: /workspace/tests
INFO     -  [macros] - Extra variables (config file): ['debug', 'latest_version_warning', 'site_root', 'version', 'analytics', 'announce']
INFO     -  [macros] - Extra filters (module): ['pretty']
WARNING  -  [git-revision-date-localized-plugin] Unable to read git logs of '/workspace/tests/docs'. Is git log readable? Option 'fallback_to_build_date' set to 'true': Falling back to build date
INFO     -  Cleaning site directory
INFO     -  Building documentation to directory: /workspace/tests/site
WARNING  -  [git-revision-date-localized-plugin] Unable to read git logs of '/workspace/tests/docs/index.md'. Is git log readable? Option 'fallback_to_build_date' set to 'true': Falling back to build date
WARNING  -  [git-revision-date-localized-plugin] Unable to read git logs of '/workspace/tests/docs/api.md'. Is git log readable? Option 'fallback_to_build_date' set to 'true': Falling back to build date

Aborted with 3 warnings in strict mode!
```

And was we rune `mkdocs build -s` wich is strict mode, warnings break the build and we should not remove strict mode ever.

This is due to https://github.blog/2022-04-12-git-security-vulnerability-announced/
> This version changes Git’s behavior when looking for a top-level .git directory to stop when its directory traversal changes ownership from the current user. (If you wish to make an exception to this behavior, you can use the new multi-valued [safe.directory](https://git-scm.com/docs/git-config/2.35.2#Documentation/git-config.txt-safedirectory) configuration).

The fix is to make the image able to run through the git log in the mounted directory (default to /workspace)

This PR adds the lines plus some updates to make the directory a build arg
Also upgrade dependencies.

## Note
This is fully backward compatible, the changes passes on the `pull_request_target` which uses the main CI workflow as well as the new.