### PR TITLE
Add home with button template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ site/
 .DS_Store
 .doctools.action-builder
 *.log
+.idea

--- a/common/custom_theme/assets/stylesheets/home_with_button.css
+++ b/common/custom_theme/assets/stylesheets/home_with_button.css
@@ -1,0 +1,13 @@
+.mdx-container {
+  padding-bottom: 10rem;
+}
+
+.mdx-hero .md-button {
+  border-radius: 0.1em;
+  font-size: 1em;
+}
+
+.mdx-hero .md-button:hover {
+  color: var(--md-primary-bg-color) !important;
+  border-color: var(--md-accent-fg-color) !important;
+}

--- a/common/custom_theme/assets/stylesheets/version.css
+++ b/common/custom_theme/assets/stylesheets/version.css
@@ -1,12 +1,6 @@
 #__version{
   border: 0;
   color: var(--md-primary-bg-color);
-  padding: 0.5em;
+  padding: 0.1em;
   border-radius: 0.1em;
-}
-
-@media screen and (min-width: 76.25em) {
-  #__version{
-    background: var(--mdx-version-bg-color);
-  }
 }

--- a/common/custom_theme/home_with_button.html
+++ b/common/custom_theme/home_with_button.html
@@ -1,0 +1,56 @@
+<!--
+  Copyright (c) 2016-2021 Martin Donath <martin.donath@squidfunk.com>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to
+  deal in the Software without restriction, including without limitation the
+  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+  sell copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+-->
+<!--SPDX-License-Identifier: Apache-2.0-->
+{% extends "main.html" %}
+{% block tabs %}
+{{ super() }}
+<section class="mdx-container">
+  <div class="md-grid md-typeset">
+    <div class="mdx-hero">
+      {% if page.meta.illustration %}
+        <div class="mdx-hero__image">
+            <img src="{{ page.meta.illustration | url }}" alt="illustration" draggable="false">
+        </div>
+      {% endif %}
+      <div class="mdx-hero__content">
+        <h1 translate="no">{{ page.meta.title }}</h1>
+        <p>{{ page.meta.description }}</p>
+        {% for link in page.meta.links %}
+        <a href="{{ link.link | url }}" title="{{ link.title | e }}"
+           class="md-button{% if loop.index <= 1 %} md-button--primary{% endif %}">
+          {{ link.title | e }}
+        </a>
+        {% endfor %}
+      </div>
+    </div>
+  </div>
+</section>
+{% endblock %}
+
+{% block content %}{% endblock %}
+{% block footer %}{% endblock %}
+
+{% block styles %}
+{{ super() }}
+<link rel="stylesheet" href="{{ 'assets/stylesheets/home.css' | url }}">
+<link rel="stylesheet" href="{{ 'assets/stylesheets/home_with_button.css' | url }}">
+{% endblock %}

--- a/tests/docs/home_with_button.md
+++ b/tests/docs/home_with_button.md
@@ -1,0 +1,27 @@
+---
+template: home_with_button.html
+title: Technical documentation for ConsenSys products
+description: Learn about and contribute to ConsenSys technical documentation.
+hide:
+  - toc
+  - navigation
+links:
+  - link: ../contribute/
+    title: Get started
+  - link: ../overview/
+    title: Learn more
+---
+
+This is a landing page, you can't add Markdown content directly.
+
+Configure the landing page using [meta tags](https://squidfunk.github.io/mkdocs-material/reference/meta-tags/) in the header:
+
+```markdown
+---
+title: Page title
+description: Page description
+links:
+  - link: link-url/
+    title: Link title
+---
+```

--- a/tests/mkdocs.yml
+++ b/tests/mkdocs.yml
@@ -20,6 +20,7 @@ theme:
 nav:
   - Home: index.md
   - API: api.md
+  - Home with button: home_with_button.md
 
 plugins:
   git-revision-date-localized:


### PR DESCRIPTION
Add new home page template that uses the same `home.html` theme but is optimized for displaying buttons without profiles.

Add custom CSS to fix the padding required for the wave background to be sized correctly on the new homepage. Also add custom CSS for the homepage buttons.

Add example that uses the new template in https://github.com/ConsenSys/doctools.template-site/pull/40.

Also, adjust CSS to simplify the version selector.