### PR TITLE
Add case check

### DIFF
--- a/.github/workflows/case.yml
+++ b/.github/workflows/case.yml
@@ -1,0 +1,17 @@
+---
+name: Check file name case
+
+on: [pull_request]
+
+jobs:
+  check:
+    name: Check file name case
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check file name case
+        uses: ConsenSys/doctools.action-builder/actions/tests/case@main
+        with:
+          DOC_DIR: tests/docs

--- a/.github/workflows/case.yml
+++ b/.github/workflows/case.yml
@@ -12,6 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Check file name case
-        uses: ConsenSys/doctools.action-builder/actions/tests/case@main
+        uses: ./actions/tests/case
         with:
           DOC_DIR: tests/docs

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set image ID and TAG
         shell: sh

--- a/.github/workflows/pr_preview_delete.yml
+++ b/.github/workflows/pr_preview_delete.yml
@@ -15,12 +15,12 @@ jobs:
 
     steps:
       - name: 'checkout code from repos'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: pr-preview
 
       - name: Checkout actions
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: actions
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Docs team
-*         @ConsenSys/protocol-pliny
-.github/  @NicolasMassart
-/actions/ @NicolasMassart
+# DocOps team
+*         @ConsenSys/consensys-docops

--- a/actions/tests/case/action.yml
+++ b/actions/tests/case/action.yml
@@ -15,15 +15,17 @@ runs:
     - name: Check pages file name case
       shell: sh
       run: |
-        if
-          find $DOC_DIR -name "*.md" | ( ! grep -P -v "^[[:lower:][:digit:]\/\-_]+\.md$" )
-        then
-          echo "::notice ::No file paths casing issue in $DOC_DIR."
-          exit 0;
-        else
-          echo "::error ::Some file paths are not lowercase in $DOC_DIR."
-          echo "::notice ::Accepted characters: lowercase letters, digits, . (dot) - (dash) and _ (underscore)"
-          echo "::notice ::Correct example: my-folder/my-file-name_new2.md"
-          echo "::notice ::Wrong example: My-Folder/MyFile-NAME.old.md"
-          exit 1;
+        echo "Testing file case in ${{ inputs.DOC_DIR }}."
+        passed=true
+        for filename in `find ${{ inputs.DOC_DIR }} -name "*.md" | ( ! grep -P -v "^[[:lower:][:digit:]\/\-_]+\.md$" )`
+        do
+          echo "$filename"
+          echo "::error file=$filename ::File path must be only lowercase letters, digits, - (dash) and _ (underscore)"
+          passed=false
+        done;
+        if [ "$passed" = false ] ; then
+          echo "::error ::Some files path are incorrect. Check error annotations in the pull request."
+          echo "Correct example: my-folder/my-file-name_new2.md"
+          echo "Wrong example: My-Folder/MyFile-NAME.old.md"
+          exit 1
         fi

--- a/actions/tests/case/action.yml
+++ b/actions/tests/case/action.yml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+name: 'Check pages file name case'
+description: 'Composite action to check case of files in doc'
+
+inputs:
+  DOC_DIR:
+    description: 'doc directory path from project root'
+    required: false
+    default: docs
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check pages file name case
+      shell: sh
+      run: |
+        if
+          find $DOC_DIR -name "*.md" | ( ! grep -P -v "^[[:lower:][:digit:]\/\-_]+\.md$" )
+        then
+          echo "::notice ::No file paths casing issue in $DOC_DIR."
+          exit 0;
+        else
+          echo "::error ::Some file paths are not lowercase in $DOC_DIR."
+          echo "::notice ::Accepted characters: lowercase letters, digits, . (dot) - (dash) and _ (underscore)"
+          echo "::notice ::Correct example: my-folder/my-file-name_new2.md"
+          echo "::notice ::Wrong example: My-Folder/MyFile-NAME.old.md"
+          exit 1;
+        fi

--- a/actions/tests/links/action.yml
+++ b/actions/tests/links/action.yml
@@ -7,7 +7,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout tools repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: ConsenSys/doctools.action-builder
         path: .doctools.action-builder

--- a/actions/tests/lint/action.yml
+++ b/actions/tests/lint/action.yml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout tools repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: ConsenSys/doctools.action-builder
         path: .doctools.action-builder


### PR DESCRIPTION
- add a CI check that forces lowercase on all .md files so users can’t push wrong casing. 
- update checkout action version to v3

This will prevent casing inconsistency in URLs.