### PR TITLE
Adjust font size on home with content

### DIFF
--- a/common/custom_theme/assets/stylesheets/home_with_content.css
+++ b/common/custom_theme/assets/stylesheets/home_with_content.css
@@ -29,8 +29,7 @@
   font-weight: 400;
   letter-spacing: .2px;
   line-height: 1.5;
-  font-size: 1rem;
-  opacity: .8;
+  font-size: 0.8rem;
 }
 
 .md-typeset .main_content_cta--container {

--- a/tests/docs/home_with_content.md
+++ b/tests/docs/home_with_content.md
@@ -28,12 +28,3 @@ Learn about how IPFS keeps your NFT immutable and permanent through
 
 ConsenSys NFT currently supports ERC-721 and ERC-1155 asset standards on Rinkeby,
 Mainnet, and Polygon.
-We're working towards supporting all EVM-compatible sidechains.
-
-The platform supports:
-
-- Custom design of token metadata via Item Types.
-- Sending NFTs via email.
-- Custom split of fees and royalties.
-- Multiple ways to sell your NFTs.
-- Webhooks to subscribe to events from ConsenSys NFT.

--- a/tests/mkdocs.yml
+++ b/tests/mkdocs.yml
@@ -21,6 +21,7 @@ nav:
   - Home: index.md
   - API: api.md
   - Home with button: home_with_button.md
+  - Home with content: home_with_content.md
 
 plugins:
   git-revision-date-localized:


### PR DESCRIPTION
On the home with content template, make body font size slightly smaller and black to match the body font on the rest of the doc site.

fixes #22 

## Preview

https://consensys.github.io/doctools.action-builder/PR-23/home_with_content/