### PR TITLE
Adjust home with content template

### DIFF
--- a/common/custom_theme/assets/stylesheets/home_with_content.css
+++ b/common/custom_theme/assets/stylesheets/home_with_content.css
@@ -10,9 +10,14 @@
   background-image: var(--dt-md-container-background-image);
 }
 
+.md-sidebar {
+  display: none !important;
+}
+
 .md-typeset h1, h2 {
   font-size: 2rem;
   line-height: 1;
+  padding-bottom: .5rem;
   margin: 0;
   color: var(--md-primary-fg-color--dark);
   font-weight: 700;


### PR DESCRIPTION
Adjust home with content template for spacing and margins.

Before:
<img width="1792" alt="Screen Shot 2022-08-12 at 2 53 27 PM" src="https://user-images.githubusercontent.com/12214231/184450217-e2dad900-4632-40c0-a6da-415e49d52f6a.png">

After
<img width="1792" alt="Screen Shot 2022-08-12 at 2 53 08 PM" src="https://user-images.githubusercontent.com/12214231/184450201-17b287f5-cbfd-429f-87a1-f6ec135dfb60.png">

